### PR TITLE
Clear lobby players when returning to main-menu

### DIFF
--- a/Assets/Scripts/Lobby/LobbyManager.cs
+++ b/Assets/Scripts/Lobby/LobbyManager.cs
@@ -161,6 +161,11 @@ public class LobbyManager : MonoBehaviour
             if (_ == GameStates.InMenu)
             {
                 Return.Disable();
+                PlayerManager.Players.ForEach(_ =>
+                {
+                    if (_.LP != null)
+                        Destroy(_.LP.gameObject);
+                });
                 PlayerManager.Players.Clear();
             }
             else


### PR DESCRIPTION
This ensures that when you return to the main-menu, the list of in-lobby players is cleared, to prevent that visual bug where the players are duplicated.